### PR TITLE
chore: change JavaVersion to 17

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,12 +54,12 @@ android {
   compileSdkVersion safeExtGet("compileSdkVersion", 31)
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
+    jvmTarget = JavaVersion.VERSION_17.majorVersion
   }
 
   defaultConfig {


### PR DESCRIPTION
On RN 0.73 and Expo 50, this package refuses to compile with an error message, unless this change is made. This project really has no reason to require JDK 11 anymore, as JDK 17 is recommended by RN docs.